### PR TITLE
Bang-bang interpolation for reference object pose

### DIFF
--- a/etc/LocomanipController.in.yaml
+++ b/etc/LocomanipController.in.yaml
@@ -194,6 +194,7 @@ FootManager:
 
 ManipManager:
   name: ManipManager
+  objPoseInterpolator: BangBang
   objHorizon: 3.0 # [sec]
   objPoseTopic: /object/pose
   objVelTopic: /object/vel

--- a/include/LocomanipController/ManipManager.h
+++ b/include/LocomanipController/ManipManager.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 
 #include <mc_rtc/constants.h>
+#include <mc_rtc/gui/Label.h>
 #include <mc_rtc/gui/StateBuilder.h>
 #include <mc_rtc/log/Logger.h>
 #include <mc_tasks/ImpedanceGains.h>
@@ -62,6 +63,9 @@ public:
   {
     //! Name
     std::string name = "ManipManager";
+
+    //! Type of object pose interpolator ("BangBang" or "Cubic")
+    std::string objPoseInterpolator = "BangBang";
 
     //! Horizon of object trajectory [sec]
     double objHorizon = 2.0;
@@ -395,7 +399,7 @@ protected:
   sva::PTransformd lastWaypointPose_ = sva::PTransformd::Identity();
 
   //! Object pose function
-  std::shared_ptr<TrajColl::CubicInterpolator<sva::PTransformd, sva::MotionVecd>> objPoseFunc_;
+  std::shared_ptr<TrajColl::Interpolator<sva::PTransformd, sva::MotionVecd>> objPoseFunc_;
 
   //! Object pose offset
   sva::PTransformd objPoseOffset_ = sva::PTransformd::Identity();

--- a/include/LocomanipController/ManipManager.h
+++ b/include/LocomanipController/ManipManager.h
@@ -35,9 +35,13 @@ struct Waypoint
       \param _startTime start time [sec]
       \param _endTime end time [sec]
       \param _pose object pose
+      \param _config additional configuration
   */
-  Waypoint(double _startTime, double _endTime, const sva::PTransformd & _pose)
-  : startTime(_startTime), endTime(_endTime), pose(_pose){};
+  Waypoint(double _startTime,
+           double _endTime,
+           const sva::PTransformd & _pose,
+           const mc_rtc::Configuration & _config = {})
+  : startTime(_startTime), endTime(_endTime), pose(_pose), config(_config){};
 
   //! Start time [sec]
   double startTime;
@@ -47,6 +51,9 @@ struct Waypoint
 
   //! Object pose
   sva::PTransformd pose;
+
+  //! Additional configuration
+  mc_rtc::Configuration config;
 };
 
 /** \brief Manipulation manager.

--- a/src/ManipManager.cpp
+++ b/src/ManipManager.cpp
@@ -4,6 +4,8 @@
 #include <mc_rtc/gui/NumberInput.h>
 #include <mc_tasks/ImpedanceTask.h>
 
+#include <TrajColl/BangBangInterpolator.h>
+
 #include <BaselineWalkingController/FootManager.h>
 #include <LocomanipController/LocomanipController.h>
 #include <LocomanipController/ManipManager.h>
@@ -15,6 +17,7 @@ using namespace LMC;
 void ManipManager::Configuration::load(const mc_rtc::Configuration & mcRtcConfig)
 {
   mcRtcConfig("name", name);
+  mcRtcConfig("objPoseInterpolator", objPoseInterpolator);
   mcRtcConfig("objHorizon", objHorizon);
   mcRtcConfig("objPoseTopic", objPoseTopic);
   mcRtcConfig("objVelTopic", objVelTopic);
@@ -64,8 +67,7 @@ void ManipManager::VelModeData::reset(bool enabled, const sva::PTransformd & cur
   objDeltaTrans_.setZero();
 }
 
-ManipManager::ManipManager(LocomanipController * ctlPtr, const mc_rtc::Configuration & mcRtcConfig)
-: ctlPtr_(ctlPtr), objPoseFunc_(std::make_shared<TrajColl::CubicInterpolator<sva::PTransformd, sva::MotionVecd>>())
+ManipManager::ManipManager(LocomanipController * ctlPtr, const mc_rtc::Configuration & mcRtcConfig) : ctlPtr_(ctlPtr)
 {
   config_.load(mcRtcConfig);
 
@@ -104,6 +106,18 @@ void ManipManager::reset()
   objPoseOffset_ = sva::PTransformd::Identity();
 
   sva::PTransformd objPoseWithoutOffset = objPoseOffset_.inv() * ctl().obj().posW();
+  if(config_.objPoseInterpolator == "Cubic")
+  {
+    objPoseFunc_ = std::make_shared<TrajColl::CubicInterpolator<sva::PTransformd, sva::MotionVecd>>();
+  }
+  else if(config_.objPoseInterpolator == "BangBang")
+  {
+    objPoseFunc_ = std::make_shared<TrajColl::BangBangInterpolator<sva::PTransformd, sva::MotionVecd>>();
+  }
+  else
+  {
+    mc_rtc::log::error_and_throw("[ManipManager] Unsupported objPoseInterpolator: {}", config_.objPoseInterpolator);
+  }
   objPoseFunc_->clearPoints();
   objPoseFunc_->appendPoint(std::make_pair(ctl().t(), objPoseWithoutOffset));
   objPoseFunc_->appendPoint(std::make_pair(ctl().t() + config_.objHorizon, objPoseWithoutOffset));
@@ -167,6 +181,7 @@ void ManipManager::addToGUI(mc_rtc::gui::StateBuilder & gui)
 
   gui.addElement(
       {ctl().name(), config_.name, "Config"},
+      mc_rtc::gui::Label("objPoseInterpolator", [this]() { return config_.objPoseInterpolator; }),
       mc_rtc::gui::NumberInput(
           "objHorizon", [this]() { return config_.objHorizon; }, [this](double v) { config_.objHorizon = v; }),
       mc_rtc::gui::NumberInput(

--- a/src/ManipManager.cpp
+++ b/src/ManipManager.cpp
@@ -527,6 +527,9 @@ void ManipManager::updateObjTraj()
 
   // Update objPoseFunc_
   {
+    auto objPoseFuncBangBang =
+        std::dynamic_pointer_cast<TrajColl::BangBangInterpolator<sva::PTransformd, sva::MotionVecd>>(objPoseFunc_);
+
     sva::PTransformd currentObjPose = lastWaypointPose_;
 
     objPoseFunc_->clearPoints();
@@ -544,7 +547,15 @@ void ManipManager::updateObjTraj()
       }
 
       currentObjPose = waypoint.pose;
-      objPoseFunc_->appendPoint(std::make_pair(waypoint.endTime, currentObjPose));
+      if(objPoseFuncBangBang)
+      {
+        double accelDuration = waypoint.config("accelDuration", 0.0);
+        objPoseFuncBangBang->appendPoint(std::make_pair(waypoint.endTime, currentObjPose), accelDuration);
+      }
+      else
+      {
+        objPoseFunc_->appendPoint(std::make_pair(waypoint.endTime, currentObjPose));
+      }
 
       if(ctl().t() + config_.objHorizon <= waypoint.endTime && !requireFootstepFollowingObj_)
       {

--- a/src/states/ConfigManipState.cpp
+++ b/src/states/ConfigManipState.cpp
@@ -161,7 +161,8 @@ bool ConfigManipState::run(mc_control::fsm::Controller &)
         {
           pose = static_cast<sva::PTransformd>(waypointConfig("relPose")) * pose;
         }
-        ctl().manipManager_->appendWaypoint(Waypoint(startTime, endTime, pose));
+        ctl().manipManager_->appendWaypoint(
+            Waypoint(startTime, endTime, pose, waypointConfig("config", mc_rtc::Configuration())));
 
         startTime = endTime;
       }


### PR DESCRIPTION
Requires https://github.com/isri-aist/TrajectoryCollection/pull/2

You can now select "BangBang" (default) or "Cubic" for `objPoseInterpolator` in the controller configuration file. A feature of bang-bang interpolation compared to cubic interpolation is that the duration of acceleration/deceleration can be adjusted.

The following configurations result in trajectories shown in the graph below.

```yaml
  LMC::ConfigManip_:
    base: LMC::ConfigManip
    configs:
      preUpdateObj: true
      preWalk: true
      waypointList:
        - startTime: 2.0
          duration: 10.0
          relPose:
            translation: [1.0, 0.0, 0.0]
          config:
            accelDuration: 0.2
        - duration: 10.0
          relPose:
            translation: [1.0, 0.0, 0.0]
          config:
            accelDuration: 3.0
```
![graph](https://github.com/isri-aist/LocomanipController/assets/6636600/6442902d-f4c4-4e23-922f-46d90f35e58b)

